### PR TITLE
Release v1.7: Undo shots/goals, line editing, overall stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hockey Tracker v1.6
+# Hockey Tracker v1.7
 
 A mobile-optimized puck possession and shot tracking app for youth hockey teams. Track individual player possession times, shots on goal, and goals during live games with detailed touch-by-touch analysis and video reference timestamps.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hockey Tracker v1.6</title>
+    <title>Hockey Tracker v1.7</title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
@@ -114,7 +114,9 @@
           const [flashPlayer, setFlashPlayer] = useState(null);
           const [swapPlayer, setSwapPlayer] = useState(null);
           const [editingLines, setEditingLines] = useState(false);
+          const [undoAction, setUndoAction] = useState(null);
           const longPressTimerRef = React.useRef(null);
+          const undoTimerRef = React.useRef(null);
           const tapTimeoutRef = React.useRef(null);
           const lastTapTimeRef = React.useRef(0);
           const lastTapPlayerRef = React.useRef(null);
@@ -160,6 +162,54 @@
             setGoalCounts(goals);
             setShotLog(slog);
             setGoalLog(glog);
+          };
+
+          const showUndoToast = (action) => {
+            clearTimeout(undoTimerRef.current);
+            setUndoAction(action);
+            undoTimerRef.current = setTimeout(() => setUndoAction(null), 5000);
+          };
+
+          const handleUndo = () => {
+            if (!undoAction) return;
+            clearTimeout(undoTimerRef.current);
+            const { type, playerId, period } = undoAction;
+
+            setShotCounts(prev => ({
+              ...prev,
+              [playerId]: {
+                ...prev[playerId],
+                [period]: Math.max((prev[playerId]?.[period] || 0) - 1, 0),
+                total: Math.max((prev[playerId]?.total || 0) - 1, 0)
+              }
+            }));
+            setShotLog(prev => ({
+              ...prev,
+              [playerId]: {
+                ...prev[playerId],
+                [period]: (prev[playerId]?.[period] || []).slice(0, -1)
+              }
+            }));
+
+            if (type === 'goal') {
+              setGoalCounts(prev => ({
+                ...prev,
+                [playerId]: {
+                  ...prev[playerId],
+                  [period]: Math.max((prev[playerId]?.[period] || 0) - 1, 0),
+                  total: Math.max((prev[playerId]?.total || 0) - 1, 0)
+                }
+              }));
+              setGoalLog(prev => ({
+                ...prev,
+                [playerId]: {
+                  ...prev[playerId],
+                  [period]: (prev[playerId]?.[period] || []).slice(0, -1)
+                }
+              }));
+            }
+
+            setUndoAction(null);
           };
 
           const triggerFlash = (playerId, type) => {
@@ -215,6 +265,7 @@
               }
             }));
             triggerFlash(playerId, 'shot');
+            showUndoToast({ type: 'shot', playerId, period: currentPeriod });
           };
 
           const recordGoal = (playerId) => {
@@ -257,6 +308,7 @@
               }
             }));
             triggerFlash(playerId, 'goal');
+            showUndoToast({ type: 'goal', playerId, period: currentPeriod });
           };
 
           const handlePointerDown = (playerId) => {
@@ -444,6 +496,8 @@
             setTouchStartTime(null);
             setEditingLines(false);
             setSwapPlayer(null);
+            clearTimeout(undoTimerRef.current);
+            setUndoAction(null);
             setGameActive(false);
 
             const gameToSave = {
@@ -1053,7 +1107,7 @@
             return (
               <div className="min-h-screen bg-slate-900 p-4">
                 <div className="max-w-md mx-auto bg-slate-800 rounded-lg p-6">
-                  <h1 className="text-2xl font-bold text-white mb-6">Hockey Tracker <span className="text-sm text-slate-400 font-normal">v1.5</span></h1>
+                  <h1 className="text-2xl font-bold text-white mb-6">Hockey Tracker <span className="text-sm text-slate-400 font-normal">v1.7</span></h1>
                   <div className="space-y-4">
                     <div>
                       <label className="block text-sm text-slate-300 mb-2">Opponent</label>
@@ -1106,7 +1160,7 @@
                       <div className="grid grid-cols-3 gap-2">
                         {players.filter(p => p.position === 'F' && p.line === line).map(p => {
                           const isFlashing = flashPlayer?.id === p.id;
-                          const flashClass = isFlashing ? (flashPlayer.type === 'goal' ? 'bg-amber-400 text-black' : 'bg-yellow-500 text-black') : '';
+                          const flashClass = isFlashing ? (flashPlayer.type === 'goal' ? 'bg-red-500 text-white' : 'bg-yellow-400 text-black') : '';
                           const isSwapSelected = editingLines && swapPlayer?.id === p.id;
                           const isSwapTarget = editingLines && swapPlayer && swapPlayer.id !== p.id;
                           return (
@@ -1124,11 +1178,23 @@
                     </div>
                   ))}
                 </div>
+                {undoAction && (() => {
+                  const p = players.find(pl => pl.id === undoAction.playerId);
+                  const label = undoAction.type === 'goal'
+                    ? `GOAL recorded for #${p?.number} ${p?.name}`
+                    : `Shot recorded for #${p?.number} ${p?.name}`;
+                  return (
+                    <div className="bg-slate-950 border border-slate-700 rounded-lg px-4 py-3 mb-3 flex justify-between items-center">
+                      <span className="text-sm text-slate-200">{label}</span>
+                      <button onClick={handleUndo} className="ml-4 bg-amber-500 hover:bg-amber-400 text-black font-bold px-4 py-1.5 rounded text-sm">Undo</button>
+                    </div>
+                  );
+                })()}
                 <div className="bg-slate-800 rounded-lg p-4">
                   <div className="grid grid-cols-2 gap-2 mb-3">
                     {players.filter(p => p.position === 'D' && p.line === activeDefenceLine).map(p => {
                       const isFlashing = flashPlayer?.id === p.id;
-                      const flashClass = isFlashing ? (flashPlayer.type === 'goal' ? 'bg-amber-400 text-black' : 'bg-yellow-500 text-black') : '';
+                      const flashClass = isFlashing ? (flashPlayer.type === 'goal' ? 'bg-red-500 text-white' : 'bg-yellow-400 text-black') : '';
                       const isSwapSelected = editingLines && swapPlayer?.id === p.id;
                       const isSwapTarget = editingLines && swapPlayer && swapPlayer.id !== p.id;
                       return (
@@ -1148,7 +1214,7 @@
                       <div className="grid grid-cols-2 gap-2">
                         {players.filter(p => p.position === 'D' && p.line === line).map(p => {
                           const isFlashing = flashPlayer?.id === p.id;
-                          const flashClass = isFlashing ? (flashPlayer.type === 'goal' ? 'bg-amber-400 text-black' : 'bg-yellow-500 text-black') : '';
+                          const flashClass = isFlashing ? (flashPlayer.type === 'goal' ? 'bg-red-500 text-white' : 'bg-yellow-400 text-black') : '';
                           const isSwapSelected = editingLines && swapPlayer?.id === p.id;
                           const isSwapTarget = editingLines && swapPlayer && swapPlayer.id !== p.id;
                           return (


### PR DESCRIPTION
## Summary
- **Undo for shots/goals**: Toast appears for 5 seconds after recording a shot or goal, with an Undo button to revert accidental inputs
- **In-game line editing**: Tap-to-swap players between lines during active games
- **Overall stats**: Aggregated stats report across all saved games with CSV export
- **Quality of life**: Distinct flash colors (red for goals, yellow for shots), delete confirmation for game history, roster persistence to localStorage, roster reset after ending a game

## Commits included
- Add undo for shots/goals and update version to v1.7
- Reset roster to saved state after ending a game
- Update version to v1.6 and persist roster to localStorage
- Update version to v1.5 and document same-line player swapping
- Fix swapping players on the same line by also swapping array positions
- Add in-game line editing with tap-to-swap during active games
- Rename Import CSV button to Import Roster from CSV
- Add overall stats report across all games (v1.3)
- Add confirmation dialog before deleting historical game reports

## Test plan
- [ ] Start a game, long-press a player → shot recorded, undo toast appears
- [ ] Tap Undo → shot count reverts, toast disappears
- [ ] Double-tap a player → goal recorded with red flash, undo reverts both shot and goal
- [ ] Wait 5 seconds → toast auto-dismisses
- [ ] Edit lines mid-game → swap players between lines
- [ ] End game → roster resets to saved state, results show correct counts
- [ ] Check History → Overall Stats shows aggregated data across games

🤖 Generated with [Claude Code](https://claude.com/claude-code)